### PR TITLE
Replace com.fortitudetec with org.kiwiproject in several files

### DIFF
--- a/elucidation-bundle/README.md
+++ b/elucidation-bundle/README.md
@@ -9,9 +9,9 @@ A bundle for Dropwizard to support the collection and reporting of Elucidation e
 #### Maven
 ```xml
 <dependency>
-    <groupId>com.fortitudetec</groupId>
+    <groupId>org.kiwiproject</groupId>
     <artifactId>elucidation-bundle</artifactId>
-    <version>4.0.0</version>
+    <version>[current-version]</version>
 </dependency>
 ```
 

--- a/elucidation-bundle/config.yml
+++ b/elucidation-bundle/config.yml
@@ -6,5 +6,5 @@ dataSourceFactory:
 logging:
   level: INFO
   loggers:
-    com.fortitudetec: DEBUG
+    org.kiwiproject: DEBUG
     org.jdbi.v3: TRACE

--- a/elucidation-client/README.md
+++ b/elucidation-client/README.md
@@ -7,9 +7,9 @@ Installation
 
 ```xml
 <dependency>
-  <groupId>com.fortitudetec</groupId>
+  <groupId>org.kiwiproject</groupId>
   <artifactId>elucidation-client</artifactId>
-  <version>4.0.0</version>
+  <version>[current-version]</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Update the READMEs for the bundle and client modules, and the config.yml in the bundle module, to replace the original com.fortitudetec package with org.kiwiproject