### PR TITLE
Remove redundant sonar.host.url from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
         <sonar.organization>elucidation-project</sonar.organization>
         <sonar.projectKey>elucidation-project_elucidation</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
     </properties>
 


### PR DESCRIPTION
Remove the redundant sonar.host.url property from pom.xml. It is already defined in kiwi-parent and does not need to be redefined here.